### PR TITLE
Remove trailing slashes from server urls

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: "Deutscher Wetterdienst: API"
 
 servers:
-  - url: 'https://app-prod-ws.warnwetter.de/v30/'
+  - url: 'https://app-prod-ws.warnwetter.de/v30'
 
 paths:
   /stationOverviewExtended:
@@ -33,7 +33,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/StationOverview'
       servers:
-        - url: 'https://app-prod-ws.warnwetter.de/v30/'
+        - url: 'https://app-prod-ws.warnwetter.de/v30'
 
   /crowd_meldungen_overview_v2.json:
     get:
@@ -47,7 +47,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CROWDMeldung'
       servers:
-        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16/'
+        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16'
 
 
   /warnings_nowcast.json:
@@ -61,7 +61,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/WarningNowcast'
       servers:
-        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16/'
+        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16'
 
 
   /gemeinde_warnings_v2_en.json:
@@ -75,7 +75,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/GemeindeWarnings'
       servers:
-        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16/'
+        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16'
 
   /warnings_coast_en.json:
     get:
@@ -88,7 +88,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/WarningCoast'
       servers:
-        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16/'
+        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16'
 
 
   /sea_warning_text.json:
@@ -103,7 +103,7 @@ paths:
                 type: string
 
       servers:
-        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16/'
+        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16'
 
 
 
@@ -119,7 +119,7 @@ paths:
                 type: string
 
       servers:
-        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16/'
+        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16'
 
 
   /warnings_lawine.json:
@@ -134,7 +134,7 @@ paths:
                 type: string
 
       servers:
-        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16/'
+        - url: 'https://s3.eu-central-1.amazonaws.com/app-prod-static.warnwetter.de/v16'
 
 components:
   schemas:


### PR DESCRIPTION
According to the OpenAPI specifications, the server addresses must not end on a slash (see https://swagger.io/specification/#server-object). Importing this in tools like Postman generates defective URLs containing two slashes. This PR fixes this.