### PR TITLE
Rename parameter stationIds to stationsKennungen

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,6 +26,10 @@ paths:
                 - type: string
                 - type: integer
           example: [10865, G005]
+        - name: stationsKennungen
+          in: query
+          style: form
+          description: "Stationskennungen könen z.B. [hier](https://www.dwd.de/DE/leistungen/klimadatendeutschland/stationsliste.html) eingesehen werden"
           explode: false
           schema:
             type: array

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14,9 +14,18 @@ paths:
       summary: Wetterstation Daten
       parameters:
         - name: stationIds
+          deprecated: true
           in: query
           style: form
-          description: "StationsIDs könen z.B. [hier](https://www.dwd.de/DE/leistungen/klimadatendeutschland/stationsliste.html) eingesehen werden"
+          description: "Der Parameter stationIds wird in stationsKennungen umbenannt. Daher ist stationIds als veraltet markiert und wird in einer zukünftigen Version werden. Bitte nur noch den Parameter stationsKennungen verwenden. "
+          explode: false
+          schema:
+            type: array
+            items:
+              oneOf:
+                - type: string
+                - type: integer
+          example: [10865, G005]
           explode: false
           schema:
             type: array

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
   description: "Aktuelle Wetterdaten von allen Deutschen Wetterstationen"
-  version: "1.0.0"
+  version: "1.1.0"
   title: "Deutscher Wetterdienst: API"
 
 servers:


### PR DESCRIPTION
The parameter `stationIds` requires the client to provide values from the column `Stationskennung`. Hence, the parameter should be renamed so that the parameter name reflects the expected values.

In this first step, I have marked  the parameter `stationIds` with `deprecated: true` and adopted the `description` to explain that the parameter will be removed in a future version. A new parameter `stationsKennungen` is introduced which has the same definition as `stationsIds`.

By marking `stationsIds` as deprecated, clients have a smoother transition to the new parameter `stationsKennungen`. 


Resolves #7 